### PR TITLE
:memo: fix: change "se" -> "set"

### DIFF
--- a/docs/CONTRACT_METHODS.md
+++ b/docs/CONTRACT_METHODS.md
@@ -114,7 +114,7 @@ Returns the "view" of the state, computed by the SWC - ie. object that is a deri
 async function viewStateForTx<Input, View>(input: Input, transaction: InteractionTx): Promise<InteractionResult<State, View>>
 ```
 
-A version of the viewState method to be used from within the contract's source code. The transaction passed as an argument is the currently processed interaction transaction. The "caller" will be se to the owner of the interaction transaction, that requires to call this method.
+A version of the viewState method to be used from within the contract's source code. The transaction passed as an argument is the currently processed interaction transaction. The "caller" will be set to the owner of the interaction transaction, that requires to call this method.
 
 💡 Note! calling "interactRead" from withing contract's source code was not previously possible - this is a new feature.
 

--- a/docs/CONTRACT_METHODS.md
+++ b/docs/CONTRACT_METHODS.md
@@ -116,7 +116,7 @@ async function viewStateForTx<Input, View>(input: Input, transaction: Interactio
 
 A version of the viewState method to be used from within the contract's source code. The transaction passed as an argument is the currently processed interaction transaction. The "caller" will be set to the owner of the interaction transaction, that requires to call this method.
 
-💡 Note! calling "interactRead" from withing contract's source code was not previously possible - this is a new feature.
+💡 Note! calling "interactRead" from within contract's source code was not previously possible - this is a new feature.
 
 - `input`                the interaction input
 - `transaction`          interaction transaction


### PR DESCRIPTION
Fix typo.

PS: This file isn't on the main branch for some reason, and there is a doc (docs/MIGRATION_GUIDE.md) on the main branch that links to it. On the main branch you end up getting 404 for this page.