### PR TITLE
bug: fixed bug when trying to import module using node esm and added …

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,24 @@ All exports are stored under `warp` global variable.
 </script>
 ```
 
+#### Using esm bundles
+
+Bundle files are possible to use in esm web environment only. Use minified version for production. It is possible to use latest or specified version.
+
+```html
+<!-- Latest -->
+<script src="https://unpkg.com/warp-contracts/bundles/esm.bundle.js"></script>
+
+<!-- Latest, minified-->
+<script src="https://unpkg.com/warp-contracts/bundles/esm.bundle.min.js"></script>
+
+<!-- Specific version -->
+<script src="https://unpkg.com/warp-contracts@1.0.0/bundles/esm.bundle.js"></script>
+
+<!-- Specific version, minified -->
+<script src="https://unpkg.com/warp-contracts@1.0.0/bundles/esm.bundle.min.js"></script>
+```
+
 ### Using the Warp Gateway
 
 #### SDK version >= `0.5.0`

--- a/package.json
+++ b/package.json
@@ -5,14 +5,6 @@
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/types/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    },
-    "./esm": "bundles/esm.bundle.js",
-    "./web": "bundles/web.bundle.js"
-  },
   "sideEffects": false,
   "engines": {
     "node": ">=16.5"


### PR DESCRIPTION
…documentation to use ESM web bundles

Removed exports property from package.json, this property blocks the ability to consume the NodeJS ESM library using nodeJS ESM projects.

Also, I added some documentation on how to reference web-based ESM bundles.