### PR TITLE
feat: internal writes errors handling #213

### DIFF
--- a/src/__tests__/integration/basic/arweave-transactions-loading.ts
+++ b/src/__tests__/integration/basic/arweave-transactions-loading.ts
@@ -44,7 +44,7 @@ describe('Testing the Arweave interactions loader', () => {
     loader = new ArweaveGatewayInteractionsLoader(arweave);
     sorter = new LexicographicalInteractionsSorter(arweave);
 
-    wallet = await warp.testing.generateWallet();
+    ({ jwk: wallet } = await warp.testing.generateWallet());
 
     contractSrc = fs.readFileSync(path.join(__dirname, '../data/inf-loop-contract.js'), 'utf8');
     const { contractTxId } = await warp.createContract.deploy({

--- a/src/__tests__/integration/basic/complicated-contract.test.ts
+++ b/src/__tests__/integration/basic/complicated-contract.test.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 
 import ArLocal from 'arlocal';
-import Arweave from 'arweave';
 import { JWKInterface } from 'arweave/node/lib/wallet';
 import path from 'path';
 import { mineBlock } from '../_helpers';
@@ -30,8 +29,7 @@ describe('Testing the Warp client', () => {
 
     warp = WarpFactory.forLocal(1800);
 
-    wallet = await warp.testing.generateWallet();
-
+    ({ jwk: wallet } = await warp.testing.generateWallet());
     contractSrc = fs.readFileSync(path.join(__dirname, '../data/very-complicated-contract.js'), 'utf8');
 
     // deploying contract using the new SDK.

--- a/src/__tests__/integration/basic/deploy-write-read.test.ts
+++ b/src/__tests__/integration/basic/deploy-write-read.test.ts
@@ -42,7 +42,7 @@ describe('Testing the Warp client', () => {
 
     LoggerFactory.INST.logLevel('error');
     warp = WarpFactory.forLocal(1810);
-    wallet = await warp.testing.generateWallet();
+    ({ jwk: wallet } = await warp.testing.generateWallet());
 
     contractSrc = fs.readFileSync(path.join(__dirname, '../data/example-contract.js'), 'utf8');
     initialState = fs.readFileSync(path.join(__dirname, '../data/example-contract-state.json'), 'utf8');

--- a/src/__tests__/integration/basic/inf-loop.test.ts
+++ b/src/__tests__/integration/basic/inf-loop.test.ts
@@ -33,7 +33,7 @@ describe('Testing the Warp client', () => {
 
     LoggerFactory.INST.logLevel('error');
     warp = WarpFactory.forLocal(1830);
-    wallet = await warp.testing.generateWallet();
+    ({ jwk: wallet } = await warp.testing.generateWallet())
 
     contractSrc = fs.readFileSync(path.join(__dirname, '../data/inf-loop-contract.js'), 'utf8');
 

--- a/src/__tests__/integration/basic/pst.test.ts
+++ b/src/__tests__/integration/basic/pst.test.ts
@@ -35,8 +35,7 @@ describe('Testing the Profit Sharing Token', () => {
     warp = WarpFactory.forLocal(1820);
 
     ({ arweave } = warp);
-    wallet = await warp.testing.generateWallet();
-    walletAddress = await arweave.wallets.jwkToAddress(wallet);
+    ({ jwk: wallet, address: walletAddress } = await warp.testing.generateWallet());
 
     contractSrc = fs.readFileSync(path.join(__dirname, '../data/token-pst.js'), 'utf8');
     const stateFromFile: PstState = JSON.parse(fs.readFileSync(path.join(__dirname, '../data/token-pst.json'), 'utf8'));

--- a/src/__tests__/integration/basic/pst.test.ts
+++ b/src/__tests__/integration/basic/pst.test.ts
@@ -132,8 +132,7 @@ describe('Testing the Profit Sharing Token', () => {
   });
 
   it('should properly perform dry write with overwritten caller', async () => {
-    const newWallet = await warp.testing.generateWallet();
-    const overwrittenCaller = await arweave.wallets.jwkToAddress(newWallet);
+    const { jwk: newWallet, address: overwrittenCaller } = await warp.testing.generateWallet();
     await pst.transfer({
       target: overwrittenCaller,
       qty: 1000

--- a/src/__tests__/integration/basic/unsafe-contract.test.ts
+++ b/src/__tests__/integration/basic/unsafe-contract.test.ts
@@ -29,7 +29,7 @@ describe('Testing the Warp client', () => {
     LoggerFactory.INST.logLevel('error');
     warp = WarpFactory.forLocal(1801);
 
-    wallet = await warp.testing.generateWallet();
+    ({ jwk: wallet } = await warp.testing.generateWallet());
     contractSrc = fs.readFileSync(path.join(__dirname, '../data/token-pst-unsafe.js'), 'utf8');
 
     // deploying contract using the new SDK.

--- a/src/__tests__/integration/basic/vrf.test.ts
+++ b/src/__tests__/integration/basic/vrf.test.ts
@@ -2,20 +2,20 @@ import fs from 'fs';
 
 import ArLocal from 'arlocal';
 import Arweave from 'arweave';
-import { JWKInterface } from 'arweave/node/lib/wallet';
+import {JWKInterface} from 'arweave/node/lib/wallet';
 import path from 'path';
-import { mineBlock } from '../_helpers';
-import { Evaluate } from '@idena/vrf-js';
+import {mineBlock} from '../_helpers';
+import {Evaluate} from '@idena/vrf-js';
 import elliptic from 'elliptic';
-import { PstState, PstContract } from '../../../contract/PstContract';
-import { InteractionsLoader } from '../../../core/modules/InteractionsLoader';
-import { EvaluationOptions } from '../../../core/modules/StateEvaluator';
-import { Warp } from '../../../core/Warp';
-import { WarpFactory, defaultCacheOptions } from '../../../core/WarpFactory';
-import { GQLNodeInterface } from '../../../legacy/gqlResult';
-import { LoggerFactory } from '../../../logging/LoggerFactory';
-import { ArweaveGatewayInteractionsLoader } from '../../../core/modules/impl/ArweaveGatewayInteractionsLoader';
-import { LexicographicalInteractionsSorter } from '../../../core/modules/impl/LexicographicalInteractionsSorter';
+import {PstContract, PstState} from '../../../contract/PstContract';
+import {InteractionsLoader} from '../../../core/modules/InteractionsLoader';
+import {EvaluationOptions} from '../../../core/modules/StateEvaluator';
+import {Warp} from '../../../core/Warp';
+import {defaultCacheOptions, WarpFactory} from '../../../core/WarpFactory';
+import {GQLNodeInterface} from '../../../legacy/gqlResult';
+import {LoggerFactory} from '../../../logging/LoggerFactory';
+import {ArweaveGatewayInteractionsLoader} from '../../../core/modules/impl/ArweaveGatewayInteractionsLoader';
+import {LexicographicalInteractionsSorter} from '../../../core/modules/impl/LexicographicalInteractionsSorter';
 
 const EC = new elliptic.ec('secp256k1');
 const key = EC.genKeyPair();
@@ -65,7 +65,7 @@ describe('Testing the Profit Sharing Token', () => {
       .setInteractionsLoader(loader)
       .build();
 
-    wallet = await warp.testing.generateWallet();
+    ({ jwk: wallet, address: walletAddress } = await warp.testing.generateWallet());
     walletAddress = await arweave.wallets.jwkToAddress(wallet);
 
     contractSrc = fs.readFileSync(path.join(__dirname, '../data/token-pst.js'), 'utf8');
@@ -82,7 +82,7 @@ describe('Testing the Profit Sharing Token', () => {
       }
     };
 
-    const { contractTxId } = await warp.createContract.deploy({
+    const {contractTxId} = await warp.createContract.deploy({
       wallet,
       initState: JSON.stringify(initialState),
       src: contractSrc
@@ -122,7 +122,7 @@ describe('Testing the Profit Sharing Token', () => {
   });
 
   it('should throw if random cannot be verified', async () => {
-    const { originalTxId: txId } = await pst.writeInteraction({
+    const {originalTxId: txId} = await pst.writeInteraction({
       function: 'vrf'
     });
     await mineBlock(warp);
@@ -130,7 +130,7 @@ describe('Testing the Profit Sharing Token', () => {
     await expect(pst.readState()).rejects.toThrow('Vrf verification failed.');
     useWrongIndex.pop();
 
-    const { originalTxId: txId2 } = await pst.writeInteraction({
+    const {originalTxId: txId2} = await pst.writeInteraction({
       function: 'vrf'
     });
     await mineBlock(warp);

--- a/src/__tests__/integration/data/example-contract.js
+++ b/src/__tests__/integration/data/example-contract.js
@@ -48,4 +48,8 @@ export async function handle(state, action) {
     const value = SmartWeave.contracts.readContractState(id);
     return { result: value };
   }
+  if (action.input.function === 'justThrow') {
+    console.log('called justThrow');
+    throw new ContractError('Error from justThrow function');
+  }
 }

--- a/src/__tests__/integration/data/writing-contract.js
+++ b/src/__tests__/integration/data/writing-contract.js
@@ -8,6 +8,45 @@ export async function handle(state, action) {
     return { state };
   }
 
+  if (action.input.function === 'writeContractAutoThrow') {
+    console.log('before calling justThrow');
+    await SmartWeave.contracts.write(action.input.contractId, {
+      function: 'justThrow',
+    });
+    if (state.errorCounter === undefined) {
+      state.errorCounter = 0;
+    }
+    state.errorCounter++;
+    console.log('after calling justThrow', state.errorCounter);
+    return { state };
+  }
+  if (action.input.function === 'writeContractForceAutoThrow') {
+    await SmartWeave.contracts.write(action.input.contractId, {
+      function: 'justThrow',
+    }, true);
+    if (state.errorCounter === undefined) {
+      state.errorCounter = 0;
+    }
+    state.errorCounter++;
+    return { state };
+  }
+  if (action.input.function === 'writeContractForceNoAutoThrow') {
+    await SmartWeave.contracts.write(action.input.contractId, {
+      function: 'justThrow',
+    }, false);
+    if (state.errorCounter === undefined) {
+      state.errorCounter = 0;
+    }
+    state.errorCounter++;
+    return { state };
+  }
+  if (action.input.function === 'writeContractManualThrow') {
+    const result = await SmartWeave.contracts.write(action.input.contractId, {
+      function: 'justThrow',
+    });
+    return { state };
+  }
+
   if (action.input.function === 'writeInDepth') {
     const value1 = await SmartWeave.contracts.write(action.input.contractId1, {
       function: 'addAmountDepth',

--- a/src/__tests__/integration/internal-writes/internal-write-back.test.ts
+++ b/src/__tests__/integration/internal-writes/internal-write-back.test.ts
@@ -74,7 +74,7 @@ describe('Testing internal writes', () => {
     warp = WarpFactory.forLocal(port);
     ({ arweave } = warp);
 
-    wallet = await warp.testing.generateWallet();
+    ({ jwk: wallet } = await warp.testing.generateWallet());
 
     contractASrc = fs.readFileSync(path.join(__dirname, '../data/writing-contract.js'), 'utf8');
     contractAInitialState = fs.readFileSync(path.join(__dirname, '../data/writing-contract-state.json'), 'utf8');

--- a/src/__tests__/integration/internal-writes/internal-write-callee.test.ts
+++ b/src/__tests__/integration/internal-writes/internal-write-callee.test.ts
@@ -298,6 +298,20 @@ describe('Testing internal writes', () => {
       expect(result.cachedValue.state.errorCounter).toBeUndefined();
     });
 
+    it('should not auto throw on default settings if IW call force to NOT throw an exception ', async () => {
+      const {originalTxId} = await callingContract.writeInteraction({
+        function: 'writeContractForceNoAutoThrow',
+        contractId: calleeTxId
+      });
+      await mineBlock(warp);
+
+      const result = await callingContract.readState();
+
+      // note: in this case the calling contract "didn't notice" that the IW call failed
+      expect(result.cachedValue.errorMessages[originalTxId]).toBeUndefined();
+      expect(result.cachedValue.state.errorCounter).toEqual(1);
+    });
+
     it('should not auto throw if evaluationOptions.throwOnInternalWriteError set to false', async () => {
       callingContract.setEvaluationOptions({
         throwOnInternalWriteError: false
@@ -313,7 +327,7 @@ describe('Testing internal writes', () => {
 
       // note: in this case the calling contract "didn't notice" that the IW call failed
       expect(result.cachedValue.errorMessages[originalTxId]).toBeUndefined();
-      expect(result.cachedValue.state.errorCounter).toEqual(1);
+      expect(result.cachedValue.state.errorCounter).toEqual(2);
     });
 
     it('should auto throw if evaluationOptions.throwOnInternalWriteError set to true', async () => {
@@ -333,7 +347,7 @@ describe('Testing internal writes', () => {
       expect(result.cachedValue.errorMessages[originalTxId]).toContain('Internal write auto error for call');
 
       // this shouldn't change from the prev. test
-      expect(result.cachedValue.state.errorCounter).toEqual(1);
+      expect(result.cachedValue.state.errorCounter).toEqual(2);
     });
 
     it('should auto throw if evaluationOptions.throwOnInternalWriteError set to false and IW call force to throw an exception', async () => {
@@ -353,7 +367,7 @@ describe('Testing internal writes', () => {
       expect(result.cachedValue.errorMessages[originalTxId]).toContain('Internal write auto error for call');
 
       // this shouldn't change from the prev. test
-      expect(result.cachedValue.state.errorCounter).toEqual(1);
+      expect(result.cachedValue.state.errorCounter).toEqual(2);
     });
 
     it('should not auto throw if evaluationOptions.throwOnInternalWriteError set to true and IW call force to NOT throw an exception', async () => {
@@ -370,7 +384,7 @@ describe('Testing internal writes', () => {
       const result = await callingContract.readState();
 
       expect(result.cachedValue.errorMessages[originalTxId]).toBeUndefined();
-      expect(result.cachedValue.state.errorCounter).toEqual(2);
+      expect(result.cachedValue.state.errorCounter).toEqual(3);
     });
 
   });

--- a/src/__tests__/integration/internal-writes/internal-write-callee.test.ts
+++ b/src/__tests__/integration/internal-writes/internal-write-callee.test.ts
@@ -74,7 +74,7 @@ describe('Testing internal writes', () => {
 
   async function deployContracts() {
     warp = WarpFactory.forLocal(port);
-    wallet = await warp.testing.generateWallet();
+    ({ jwk: wallet } = await warp.testing.generateWallet())
 
     callingContractSrc = fs.readFileSync(path.join(__dirname, '../data/writing-contract.js'), 'utf8');
     callingContractInitialState = fs.readFileSync(path.join(__dirname, '../data/writing-contract-state.json'), 'utf8');

--- a/src/__tests__/integration/internal-writes/internal-write-callee.test.ts
+++ b/src/__tests__/integration/internal-writes/internal-write-callee.test.ts
@@ -279,7 +279,7 @@ describe('Testing internal writes', () => {
     });
   });
 
-  fdescribe('with internal writes throwing exceptions', () => {
+  describe('with internal writes throwing exceptions', () => {
     beforeAll(async () => {
       await deployContracts();
     });

--- a/src/__tests__/integration/internal-writes/internal-write-caller.test.ts
+++ b/src/__tests__/integration/internal-writes/internal-write-caller.test.ts
@@ -61,7 +61,6 @@ describe('Testing internal writes', () => {
 
   let wallet: JWKInterface;
 
-  let arweave: Arweave;
   let arlocal: ArLocal;
   let warp: Warp;
   let calleeContract: Contract<any>;
@@ -86,7 +85,7 @@ describe('Testing internal writes', () => {
   async function deployContracts() {
     warp = WarpFactory.forLocal(port);
 
-    wallet = await warp.testing.generateWallet();
+    ({ jwk: wallet } = await warp.testing.generateWallet())
 
     callingContractSrc = fs.readFileSync(path.join(__dirname, '../data/writing-contract.js'), 'utf8');
     callingContractInitialState = fs.readFileSync(path.join(__dirname, '../data/writing-contract-state.json'), 'utf8');

--- a/src/__tests__/integration/internal-writes/internal-write-depth.test.ts
+++ b/src/__tests__/integration/internal-writes/internal-write-depth.test.ts
@@ -60,7 +60,6 @@ describe('Testing internal writes', () => {
 
   let wallet: JWKInterface;
 
-  let arweave: Arweave;
   let arlocal: ArLocal;
   let warp: Warp;
   let contractA: Contract<any>;
@@ -87,7 +86,7 @@ describe('Testing internal writes', () => {
   async function deployContracts() {
     warp = WarpFactory.forLocal(port);
 
-    wallet = await warp.testing.generateWallet();
+    ({ jwk: wallet } = await warp.testing.generateWallet())
 
     contractASrc = fs.readFileSync(path.join(__dirname, '../data/writing-contract.js'), 'utf8');
     contractAInitialState = fs.readFileSync(path.join(__dirname, '../data/writing-contract-state.json'), 'utf8');

--- a/src/__tests__/integration/internal-writes/multi-internal-calls.test.ts
+++ b/src/__tests__/integration/internal-writes/multi-internal-calls.test.ts
@@ -80,7 +80,7 @@ describe('Testing internal writes', () => {
 
   async function deployContracts() {
     warp = WarpFactory.forLocal(port);
-    wallet = await warp.testing.generateWallet();
+    ({ jwk: wallet } = await warp.testing.generateWallet())
 
     contractASrc = fs.readFileSync(path.join(__dirname, '../data/writing-contract.js'), 'utf8');
     contractAInitialState = fs.readFileSync(path.join(__dirname, '../data/writing-contract-state.json'), 'utf8');

--- a/src/__tests__/integration/internal-writes/staking.test.ts
+++ b/src/__tests__/integration/internal-writes/staking.test.ts
@@ -56,8 +56,7 @@ describe('Testing internal writes', () => {
     warp = WarpFactory.forLocal(port);
     ({ arweave } = warp);
 
-    wallet = await warp.testing.generateWallet();
-    walletAddress = await arweave.wallets.jwkToAddress(wallet);
+    ({ jwk: wallet, address: walletAddress } = await warp.testing.generateWallet());
 
     tokenContractSrc = fs.readFileSync(path.join(__dirname, '../data/staking/erc-20.js'), 'utf8');
     tokenContractInitialState = fs.readFileSync(path.join(__dirname, '../data/staking/erc-20.json'), 'utf8');

--- a/src/__tests__/integration/wasm/as-deploy-write-read.test.ts
+++ b/src/__tests__/integration/wasm/as-deploy-write-read.test.ts
@@ -41,7 +41,7 @@ describe('Testing the Warp client for AssemblyScript WASM contract', () => {
     warp = WarpFactory.forLocal(1300);
     ({ arweave } = warp);
 
-    wallet = await warp.testing.generateWallet();
+    ({ jwk: wallet } = await warp.testing.generateWallet())
     contractSrc = fs.readFileSync(path.join(__dirname, '../data/wasm/as/assemblyscript-counter.wasm'));
     initialState = fs.readFileSync(path.join(__dirname, '../data/wasm/counter-init-state.json'), 'utf8');
 

--- a/src/__tests__/integration/wasm/go-deploy-write-read.test.ts
+++ b/src/__tests__/integration/wasm/go-deploy-write-read.test.ts
@@ -39,7 +39,7 @@ describe('Testing the Go WASM Profit Sharing Token', () => {
     warp = WarpFactory.forLocal(1150);
     ({ arweave } = warp);
 
-    wallet = await warp.testing.generateWallet();
+    ({ jwk: wallet } = await warp.testing.generateWallet())
     walletAddress = await arweave.wallets.jwkToAddress(wallet);
 
     const contractSrc = fs.readFileSync(path.join(__dirname, '../data/wasm/go/go-pst.wasm'));

--- a/src/__tests__/integration/wasm/rust-deploy-write-read.test.ts
+++ b/src/__tests__/integration/wasm/rust-deploy-write-read.test.ts
@@ -44,7 +44,7 @@ describe('Testing the Rust WASM Profit Sharing Token', () => {
     ({ arweave } = warp);
     arweaveWrapper = new ArweaveWrapper(arweave);
 
-    wallet = await warp.testing.generateWallet();
+    ({ jwk: wallet } = await warp.testing.generateWallet());
     walletAddress = await arweave.wallets.jwkToAddress(wallet);
 
     const contractSrc = fs.readFileSync(path.join(__dirname, '../data/wasm/rust/rust-pst_bg.wasm'));

--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -12,6 +12,13 @@ export type BenchmarkStats = { gatewayCommunication: number; stateEvaluation: nu
 
 export type SigningFunction = (tx: Transaction) => Promise<void>;
 
+export class ContractError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ContractError';
+  }
+}
+
 interface BundlrResponse {
   id: string;
   public: string;

--- a/src/contract/testing/Testing.ts
+++ b/src/contract/testing/Testing.ts
@@ -1,6 +1,11 @@
 import Arweave from 'arweave';
 import { JWKInterface } from 'arweave/node/lib/wallet';
 
+export type Wallet = {
+  jwk: JWKInterface;
+  address: string;
+};
+
 export class Testing {
   constructor(private readonly arweave: Arweave) {}
 
@@ -9,12 +14,15 @@ export class Testing {
     await this.arweave.api.get('mine');
   }
 
-  async generateWallet(): Promise<JWKInterface> {
+  async generateWallet(): Promise<Wallet> {
     this.validateEnv();
     const wallet = await this.arweave.wallets.generate();
     await this.addFunds(wallet);
 
-    return wallet;
+    return {
+      jwk: wallet,
+      address: await this.arweave.wallets.jwkToAddress(wallet)
+    };
   }
 
   private async addFunds(wallet: JWKInterface) {

--- a/src/core/WarpFactory.ts
+++ b/src/core/WarpFactory.ts
@@ -102,7 +102,6 @@ export class WarpFactory {
     if (useArweaveGw) {
       return this.customArweaveGw(arweave, cacheOptions, 'mainnet');
     } else {
-      console.log(defaultWarpGwOptions);
       return this.customWarpGw(arweave, defaultWarpGwOptions, cacheOptions, 'mainnet');
     }
   }

--- a/src/core/modules/StateEvaluator.ts
+++ b/src/core/modules/StateEvaluator.ts
@@ -100,7 +100,7 @@ export class DefaultEvaluationOptions implements EvaluationOptions {
   // "false" may lead to some fairly simple attacks on contract, if the contract
   // does not properly validate input data.
   // "true" may lead to wrongly calculated state, even without noticing the problem
-  // (eg. when using unsafe client and Arweave does not respond properly for a while)
+  // (e.g. when using unsafe client and Arweave does not respond properly for a while)
   ignoreExceptions = true;
 
   waitForConfirmation = false;
@@ -132,6 +132,8 @@ export class DefaultEvaluationOptions implements EvaluationOptions {
   walletBalanceUrl = 'http://nyc-1.dev.arweave.net:1984/';
 
   mineArLocalBlocks = true;
+
+  throwOnInternalWriteError = true;
 }
 
 // an interface for the contract EvaluationOptions - can be used to change the behaviour of some features.
@@ -206,4 +208,8 @@ export interface EvaluationOptions {
 
   // whether the local Warp instance should manually mine blocks in ArLocal. Defaults to true.
   mineArLocalBlocks: boolean;
+
+  // whether a contract should automatically throw if internal write fails.
+  // set to 'true' be default, can be set to false for backwards compatibility
+  throwOnInternalWriteError: boolean;
 }

--- a/src/core/modules/impl/DefaultStateEvaluator.ts
+++ b/src/core/modules/impl/DefaultStateEvaluator.ts
@@ -137,6 +137,7 @@ export abstract class DefaultStateEvaluator implements StateEvaluator {
         const newState = await this.internalWriteState<State>(contractDefinition.txId, missingInteraction.sortKey);
         if (newState !== null) {
           currentState = newState.cachedValue.state;
+          console.log(currentState);
           // we need to update the state in the wasm module
           executionContext?.handler.initState(currentState);
 

--- a/src/core/modules/impl/DefaultStateEvaluator.ts
+++ b/src/core/modules/impl/DefaultStateEvaluator.ts
@@ -137,7 +137,6 @@ export abstract class DefaultStateEvaluator implements StateEvaluator {
         const newState = await this.internalWriteState<State>(contractDefinition.txId, missingInteraction.sortKey);
         if (newState !== null) {
           currentState = newState.cachedValue.state;
-          console.log(currentState);
           // we need to update the state in the wasm module
           executionContext?.handler.initState(currentState);
 

--- a/src/core/modules/impl/handler/AbstractContractHandler.ts
+++ b/src/core/modules/impl/handler/AbstractContractHandler.ts
@@ -75,7 +75,6 @@ export abstract class AbstractContractHandler<State> implements HandlerApi<State
         ? `Internal write auto error for call [${JSON.stringify(debugData)}]: ${result.errorMessage}`
         : result.errorMessage;
 
-      console.log('new state', result.state);
       await executionContext.warp.stateEvaluator.onInternalWriteStateUpdate(this.swGlobal._activeTx, contractTxId, {
         state: result.state as State,
         validity: {
@@ -87,9 +86,6 @@ export abstract class AbstractContractHandler<State> implements HandlerApi<State
           [this.swGlobal._activeTx.id]: effectiveErrorMessage
         }
       });
-      console.log('result.type', result.type);
-      console.log('effectiveThrowOnError', effectiveThrowOnError);
-      console.log('this.swGlobal._activeTx.dry', this.swGlobal._activeTx.dry);
       if (shouldAutoThrow) {
         throw new ContractError(effectiveErrorMessage);
       }

--- a/src/legacy/smartweave-global.ts
+++ b/src/legacy/smartweave-global.ts
@@ -79,7 +79,7 @@ export class SmartWeaveGlobal {
         throw new Error('Not implemented - should be set by HandlerApi implementor');
       },
 
-      write: (contractId: string, input: any) => {
+      write: (contractId: string, input: any, throwOnError?: boolean) => {
         throw new Error('Not implemented - should be set by HandlerApi implementor');
       },
 


### PR DESCRIPTION
wondering if the new `evaluationOptions.throwOnInternalWriteError` option should be true by default - as it might break backwards compatibility...or maybe we should set to `false` for some time (a month after release) and switch to `true` later?