### PR TITLE
Fix compatibility with newer versions of wasm-bindgen (Rust contracts)

### DIFF
--- a/src/core/modules/impl/wasm/wasm-bindgen-tools.ts
+++ b/src/core/modules/impl/wasm/wasm-bindgen-tools.ts
@@ -1,5 +1,5 @@
 export function matchMutClosureDtor(source: string) {
-  const regexp = /var ret = makeMutClosure\(arg0, arg1, (\d+?), __wbg_adapter/;
+  const regexp = /(const|var) ret = makeMutClosure\(arg0, arg1, (\d+?), __wbg_adapter/;
   const match = source.match(regexp);
-  return match[1];
+  return match[2];
 }


### PR DESCRIPTION
There has been a change in the way `wasm-bindgen` generate the javascript glue code when compiling to WASM, which breaks an assumption Warp makes about its shape. Starting from the version `0.7.80` of wasm-bindgen, variables in the javascript glue code are now declared using `const` instead of `var`, which conflicts with the way Warp is extracting information from this code.

This PR fixes this compatibility issue by modifying the regex used to read the `dtor` value.