### PR TITLE
fix Vrf's randomInt binding in Rust imports

### DIFF
--- a/src/core/modules/impl/wasm/rust-wasm-imports.ts
+++ b/src/core/modules/impl/wasm/rust-wasm-imports.ts
@@ -276,8 +276,8 @@ export const rustWasmImports = (swGlobal, wbindgenImports, wasmInstance, dtorVal
       getInt32Memory0()[arg0 / 4 + 0] = ptr0;
     },
 
-    __wbg_randomInt: function (arg0, arg1) {
-      var ret = rawImports.Vrf.randomInt(arg1);
+    __wbg_randomInt: function (arg0) {
+      var ret = rawImports.Vrf.randomInt(arg0);
       return ret;
     }
   };


### PR DESCRIPTION
Trying to use Vrf's `randomInt` function in a Rust contract results in the error `Integer max value required for random integer generation` being thrown. I pinpointed the source of the error to `rust-wasm-imports.ts`: the binding accepts two arguments and use the second one to call `randomInt` while it should only accept one argument.