### PR TITLE
fix: prevent wrapping contract Error

### DIFF
--- a/src/core/modules/impl/handler/WasmHandlerApi.ts
+++ b/src/core/modules/impl/handler/WasmHandlerApi.ts
@@ -42,6 +42,10 @@ export class WasmHandlerApi<State> extends AbstractContractHandler<State> {
         gasUsed: this.swGlobal.gasUsed
       };
     } catch (e) {
+      if (!(e instanceof Error)) {
+        throw e;
+      }
+
       // note: as exceptions handling in WASM is currently somewhat non-existent
       // https://www.assemblyscript.org/status.html#exceptions
       // and since we have to somehow differentiate different types of exceptions
@@ -124,6 +128,7 @@ export class WasmHandlerApi<State> extends AbstractContractHandler<State> {
           if (errorKey == 'RuntimeError') {
             throw new Error(`[RE:RE]${errorArgs}`);
           } else {
+            throw handleResult.Err;
             throw new Error(`[CE:${errorKey}${errorArgs}]`);
           }
         }


### PR DESCRIPTION
Expose the actual contract error object for Rust contracts. This allows for precise contract error checking. See https://github.com/pianity/pianity-smartcontracts-next/blob/36ba4b8eb37f14f3f71ac8596094b61d2a30bebd/tests/src/fee.test.ts#L144 for a simple example of what it enables.

Note: it throws the exact error object that was returned by the contract. Not sure if we'd want to wrap it into a custom `Error` object?