### PR TITLE
feat: dedicated cache for contract source

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   // Automatically clear mock calls and instances between every test
   clearMocks: true,
-
+  testTimeout: 30000,
   moduleFileExtensions: ['ts', 'js'],
 
   testPathIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "test:unit:cache": "jest ./src/__tests__/unit/cache-leveldb.test.ts",
     "test:unit:cache:real": "jest ./src/__tests__/unit/cache-leveldb-real-data.test.ts",
     "test:integration:basic": "jest ./src/__tests__/integration/basic",
+    "test:integration:basic:load": "jest --silent=false --detectOpenHandles ./src/__tests__/integration/basic/contract-loading.test.ts ",
+    "test:integration:basic:arweave": "jest ./src/__tests__/integration/basic/arweave-transactions-loading",
     "test:integration:internal-writes": "jest ./src/__tests__/integration/internal-writes",
     "test:integration:wasm": "jest ./src/__tests__/integration/wasm",
     "test:regression": "node ./node_modules/.bin/jest ./src/__tests__/regression"

--- a/src/__tests__/integration/basic/contract-loading.test.ts
+++ b/src/__tests__/integration/basic/contract-loading.test.ts
@@ -1,0 +1,130 @@
+import fs from 'fs';
+
+import ArLocal from 'arlocal';
+import { JWKInterface } from 'arweave/node/lib/wallet';
+import path from 'path';
+import { mineBlock } from '../_helpers';
+import { Contract } from '../../../contract/Contract';
+import { Warp } from '../../../core/Warp';
+import { WarpFactory, defaultCacheOptions } from '../../../core/WarpFactory';
+import { GQLNodeInterface } from '../../../legacy/gqlResult';
+import { LoggerFactory } from '../../../logging/LoggerFactory';
+import { WarpGatewayContractDefinitionLoader } from '../../../core/modules/impl/WarpGatewayContractDefinitionLoader';
+import { DefaultEvaluationOptions } from '../../../core/modules/StateEvaluator';
+import { LexicographicalInteractionsSorter } from '../../../core/modules/impl/LexicographicalInteractionsSorter';
+import { LevelDbCache } from '../../../cache/impl/LevelDbCache';
+
+
+interface ExampleContractState {
+  counter: number;
+}
+
+describe('Testing WarpGatewayContractDefinitionLoader', () => {
+  let contractSrc: string;
+  let wallet: JWKInterface;
+  let loader: WarpGatewayContractDefinitionLoader;
+
+  const evalOptions = new DefaultEvaluationOptions();
+  let sorter: LexicographicalInteractionsSorter;
+  let interactions: GQLNodeInterface[];
+
+  let arlocal: ArLocal;
+  let warp: Warp;
+  let contract: Contract<ExampleContractState>;
+
+  beforeAll(async () => {
+    LoggerFactory.INST.logLevel('error');
+    // note: each tests suit (i.e. file with tests that Jest is running concurrently
+    // with another files has to have ArLocal set to a different port!)
+    const port = 1832
+    arlocal = new ArLocal(port, false);
+    await arlocal.start();
+
+    warp = WarpFactory.forLocal(port)
+  
+    const { arweave } = warp;
+
+    const contractCache = new LevelDbCache<any>({ ...defaultCacheOptions, inMemory: true });
+    const srcCache = new LevelDbCache<any>({ ...defaultCacheOptions, inMemory: true });
+
+    loader = new WarpGatewayContractDefinitionLoader("localhost:1832", arweave, contractCache, srcCache, 'local');
+    sorter = new LexicographicalInteractionsSorter(arweave);
+
+    ({ jwk: wallet } = await warp.generateWallet());
+
+    contractSrc = fs.readFileSync(path.join(__dirname, '../data/contract-load-first.js'), 'utf8');
+    const { contractTxId } = await warp.deploy({
+      wallet,
+      initState: JSON.stringify({
+        counter: 10
+      }),
+      src: contractSrc
+    });
+
+    contract = warp
+      .contract<ExampleContractState>(contractTxId)
+      .setEvaluationOptions({
+        maxInteractionEvaluationTimeSeconds: 1,
+        mineArLocalBlocks: false
+      })
+      .connect(wallet);
+
+    await mineBlock(warp);
+  });
+
+  afterAll(async () => {
+    await arlocal.stop();
+  });
+
+  it('loads contract definition when cache is empty', async () => {
+    // Cache is empty
+    loader.getCache().delete(contract.txId())
+    expect(await loader.getCache().get(contract.txId(), "cd")).toBeFalsy()
+
+    // Load contract
+    const loaded = await loader.load(contract.txId());
+    expect(loaded.txId).toBe(contract.txId());
+    expect(loaded.src).toBe(contractSrc);
+
+    // Contract is in its cache
+    expect(await loader.getCache().get(loaded.txId, "cd")).toBeTruthy()
+    expect(await loader.getSrcCache().get(loaded.txId, "cd")).toBeFalsy()
+
+    // Source is in its cache
+    expect(await loader.getCache().get(loaded.srcTxId, "src")).toBeFalsy()
+    expect(await loader.getSrcCache().get(loaded.srcTxId, "src")).toBeTruthy()
+  });
+
+  it('loads contract definition when cache contains given definition', async () => {
+    // Loads contract and source
+    let loaded = await loader.load(contract.txId());
+
+    // Modify source in cache
+    let source = await loader.getSrcCache().get(loaded.srcTxId, "src")
+    expect(source).toBeTruthy()
+    source!.cachedValue.src = fs.readFileSync(path.join(__dirname, '../data/token-evolve.js'), 'utf8');
+    await loader.getSrcCache().put({ contractTxId: loaded.srcTxId, sortKey: "src" }, source!.cachedValue)
+
+    // Load again, modified cache should be returned
+    loaded = await loader.load(contract.txId());
+    expect(loaded.src).toBe(source!.cachedValue.src)
+  });
+
+  it('loads contract definition with an evolved source code', async () => {
+    const newSource = fs.readFileSync(path.join(__dirname, '../data/contract-load-second.js'), 'utf8');
+
+    const srcTx = await warp.createSourceTx({ src: newSource }, wallet);
+    const newSrcTxId = await warp.saveSourceTx(srcTx);
+    await mineBlock(warp);
+
+    await contract.evolve(newSrcTxId)
+    await mineBlock(warp);
+
+    const loaded = await loader.load(contract.txId(), newSrcTxId);
+    expect(loaded.src).toBe(newSource)
+    expect(loaded.srcTxId).toBe(newSrcTxId)
+  });
+
+
+
+});

--- a/src/__tests__/integration/data/contract-load-first.js
+++ b/src/__tests__/integration/data/contract-load-first.js
@@ -1,0 +1,34 @@
+// First
+export async function handle(state, action) {
+  if (state.counter === undefined) {
+    state.counter = 0;
+  }
+
+  if (action.input.function === 'loop') {
+    let i = 0;
+    // well, not really an inf. loop, as Jest will cry here
+    // that async operations were not stopped.
+    while (i++ < 2) {
+      await timeout(1000);
+      state.counter++;
+    }
+
+    return { state };
+  }
+
+  if (action.input.function === 'add') {
+    state.counter += 10;
+    return { state };
+  }
+
+  if (action.input.function === 'evolve') {
+    state.isEvolved = true
+    return { state };
+  }
+
+  function timeout(delay) {
+    return new Promise(function (resolve) {
+      setTimeout(resolve, delay);
+    });
+  }
+}

--- a/src/__tests__/integration/data/contract-load-second.js
+++ b/src/__tests__/integration/data/contract-load-second.js
@@ -1,0 +1,34 @@
+// Second
+export async function handle(state, action) {
+  if (state.counter === undefined) {
+    state.counter = 0;
+  }
+
+  if (action.input.function === 'loop') {
+    let i = 0;
+    // well, not really an inf. loop, as Jest will cry here
+    // that async operations were not stopped.
+    while (i++ < 01) {
+      await timeout(1000);
+      state.counter+=10;
+    }
+
+    return { state };
+  }
+
+  if (action.input.function === 'add') {
+    state.counter += 10;
+    return { state };
+  }
+
+  if (action.input.function === 'evolve') {
+    state.isEvolved = true
+    return { state };
+  }
+
+  function timeout(delay) {
+    return new Promise(function (resolve) {
+      setTimeout(resolve, delay);
+    });
+  }
+}

--- a/src/core/ContractDefinition.ts
+++ b/src/core/ContractDefinition.ts
@@ -17,12 +17,21 @@ export type ContractSource = {
   metadata?: ContractMetadata;
 };
 
-export type ContractDefinition<State> = {
-  txId: string;
-  srcTxId: string;
+export class SrcCache {
   src: string | null;
   srcBinary: Buffer | null;
   srcWasmLang: string | null;
+
+  constructor(value: ContractDefinition<any>) {
+    this.src = value.src;
+    this.srcBinary = value.srcBinary;
+    this.srcWasmLang = value.srcWasmLang;
+  }
+}
+
+export class ContractCache<State> {
+  txId: string;
+  srcTxId: string;
   initState: State;
   minFee: string;
   owner: string;
@@ -32,4 +41,19 @@ export type ContractDefinition<State> = {
   contractTx: any;
   srcTx: any;
   testnet: string | null;
-};
+
+  constructor(value: ContractDefinition<State>) {
+    this.txId = value.txId;
+    this.srcTxId = value.srcTxId;
+    this.initState = value.initState;
+    this.minFee = value.minFee;
+    this.owner = value.owner;
+    this.contractType = value.contractType;
+    this.metadata = value.metadata;
+    this.contractTx = value.contractTx;
+    this.srcTx = value.srcTx;
+    this.testnet = value.testnet;
+  }
+}
+
+export type ContractDefinition<State> = SrcCache & ContractCache<State>;

--- a/src/core/Warp.ts
+++ b/src/core/Warp.ts
@@ -20,7 +20,7 @@ import { EvalStateResult, StateEvaluator } from './modules/StateEvaluator';
 import { WarpBuilder } from './WarpBuilder';
 import { WarpPluginType, WarpPlugin, knownWarpPlugins } from './WarpPlugin';
 import { SortKeyCache } from '../cache/SortKeyCache';
-import { ContractDefinition } from './ContractDefinition';
+import { ContractDefinition, SrcCache } from './ContractDefinition';
 import { SignatureType } from '../contract/Signature';
 import { SourceData } from '../contract/deploy/impl/SourceImpl';
 import Transaction from 'arweave/node/lib/transaction';
@@ -106,8 +106,9 @@ export class Warp {
     return this;
   }
 
-  useContractCache(contractsCache: SortKeyCache<ContractDefinition<any>>): Warp {
-    this.definitionLoader.setCache(contractsCache);
+  useContractCache(definition: SortKeyCache<ContractDefinition<any>>, src: SortKeyCache<SrcCache>): Warp {
+    this.definitionLoader.setSrcCache(src);
+    this.definitionLoader.setCache(definition);
     return this;
   }
 

--- a/src/core/WarpBuilder.ts
+++ b/src/core/WarpBuilder.ts
@@ -69,10 +69,17 @@ export class WarpBuilder {
       dbLocation: `${cacheOptions.dbLocation}/contracts`
     });
 
+    // Separate cache for sources to minimize duplicates
+    const sourceCache = new LevelDbCache({
+      ...cacheOptions,
+      dbLocation: `${cacheOptions.dbLocation}/source`
+    });
+
     this._definitionLoader = new WarpGatewayContractDefinitionLoader(
       gatewayOptions.address,
       this._arweave,
       contractsCache,
+      sourceCache,
       this._environment
     );
     return this;

--- a/src/core/modules/DefinitionLoader.ts
+++ b/src/core/modules/DefinitionLoader.ts
@@ -1,4 +1,4 @@
-import { ContractDefinition, ContractSource } from '../../core/ContractDefinition';
+import { ContractCache, ContractDefinition, ContractSource, SrcCache } from '../../core/ContractDefinition';
 import { GwTypeAware } from './InteractionsLoader';
 import { SortKeyCache } from '../../cache/SortKeyCache';
 
@@ -12,7 +12,12 @@ export interface DefinitionLoader extends GwTypeAware {
 
   loadContractSource(srcTxId: string): Promise<ContractSource>;
 
-  setCache(cache: SortKeyCache<ContractDefinition<any>>): void;
+  setCache(cache: SortKeyCache<ContractCache<any>>): void;
 
-  getCache(): SortKeyCache<ContractDefinition<any>>;
+  // Cache for storing common source code or binaries
+  setSrcCache(cacheSrc?: SortKeyCache<SrcCache>): void;
+
+  getCache(): SortKeyCache<ContractCache<any>>;
+
+  getSrcCache(): SortKeyCache<SrcCache>;
 }

--- a/src/core/modules/impl/ContractDefinitionLoader.ts
+++ b/src/core/modules/impl/ContractDefinitionLoader.ts
@@ -1,7 +1,7 @@
 import Arweave from 'arweave';
 import Transaction from 'arweave/node/lib/transaction';
 import { ContractType } from '../../../contract/deploy/CreateContract';
-import { ContractDefinition, ContractSource } from '../../../core/ContractDefinition';
+import { ContractDefinition, ContractSource, ContractCache, SrcCache } from '../../../core/ContractDefinition';
 import { SmartWeaveTags } from '../../../core/SmartWeaveTags';
 import { Benchmark } from '../../../logging/Benchmark';
 import { LoggerFactory } from '../../../logging/LoggerFactory';
@@ -146,7 +146,16 @@ export class ContractDefinitionLoader implements DefinitionLoader {
   setCache(cache: SortKeyCache<ContractDefinition<any>>): void {
     throw new Error('No cache implemented for this loader');
   }
-  getCache(): SortKeyCache<ContractDefinition<any>> {
+
+  setSrcCache(cache: SortKeyCache<SrcCache>): void {
+    throw new Error('No cache implemented for this loader');
+  }
+
+  getCache(): SortKeyCache<ContractCache<any>> {
+    throw new Error('No cache implemented for this loader');
+  }
+
+  getSrcCache(): SortKeyCache<SrcCache> {
     throw new Error('No cache implemented for this loader');
   }
 }


### PR DESCRIPTION
Split cache to avoid duplicates, described in #261