### PR TITLE
expose Uint32Array to vm2

### DIFF
--- a/src/core/modules/impl/HandlerExecutorFactory.ts
+++ b/src/core/modules/impl/HandlerExecutorFactory.ts
@@ -186,6 +186,19 @@ export class HandlerExecutorFactory implements ExecutorFactory<HandlerApi<unknow
       }
       if (evaluationOptions.useVM2) {
         const vmScript = new vm2.VMScript(normalizedSource);
+	const typedArrays = {
+          Int8Array: Int8Array,
+          Uint8Array: Uint8Array,
+          Uint8ClampedArray: Uint8ClampedArray,
+          Int16Array: Int16Array,
+          Uint16Array: Uint16Array,
+          Int32Array: Int32Array,
+          Uint32Array: Uint32Array,
+          Float32Array: Float32Array,
+          Float64Array: Float64Array,
+          BigInt64Array: BigInt64Array,
+          BigUint64Array: BigUint64Array
+	}
         const vm = new vm2.NodeVM({
           console: 'off',
           sandbox: {
@@ -197,8 +210,7 @@ export class HandlerExecutorFactory implements ExecutorFactory<HandlerApi<unknow
               if (!cond) throw new ContractError(message);
             },
             //https://github.com/patriksimek/vm2/issues/484#issuecomment-1327479592
-            Uint8Array: Uint8Array,
-            Uint32Array: Uint32Array
+            ...typedArrays
           },
           compiler: 'javascript',
           eval: false,

--- a/src/core/modules/impl/HandlerExecutorFactory.ts
+++ b/src/core/modules/impl/HandlerExecutorFactory.ts
@@ -197,7 +197,8 @@ export class HandlerExecutorFactory implements ExecutorFactory<HandlerApi<unknow
               if (!cond) throw new ContractError(message);
             },
             //https://github.com/patriksimek/vm2/issues/484#issuecomment-1327479592
-            Uint8Array: Uint8Array
+            Uint8Array: Uint8Array,
+            Uint32Array: Uint32Array
           },
           compiler: 'javascript',
           eval: false,


### PR DESCRIPTION
A couple of weeks ago, you made a modification to the vm2 settings to make it work with the WeaveDB contracts.

Unfortunately, it solved one issue but introduced a bunch of new problems in our contracts. We have been talking about it here https://github.com/weavedb/weavedb/issues/134.

I have rewritten the crypto libraries we were using to authenticate wallet addresses and figured out a way to make it all work with vm2.

You could expose `Uint32Array` in the same way you exposed `Uint8Array` since some crypto libraries depend on it, and you should be able to evaluate this new WeaveDB contract correctly.
https://sonar.warp.cc/?#/app/contract/GFmHBdJmRlTAaCA7RpjY04vXPHc208S0pTuY72g1IBw

For the old WeaveDB contracts, you need to use warp-contracts@1.2.26 without vm2 turned on. But it's not as important for us to fix old ones as to make it future-proof with your updates since we've only made demo dapps so far (we can migrate the whole data to new contracts if necessary).