### PR TITLE
fix: reading owner of tx in strict mode

### DIFF
--- a/src/__tests__/integration/basic/pst.test.ts
+++ b/src/__tests__/integration/basic/pst.test.ts
@@ -155,4 +155,22 @@ describe('Testing the Profit Sharing Token', () => {
     expect(result.state.balances['uhE-QeYS8i4pmUtnxQyHD7dzXFNaJ9oMK-IM-QPNY6M']).toEqual(10000000 + 555 + 333);
     expect(result.state.balances[overwrittenCaller]).toEqual(1000 - 333);
   });
+
+  describe('when in strict mode', () => {
+    it('should properly extract owner from signature, using arweave wallet', async () => {
+      const startBalance = (await pst.currentBalance(walletAddress)).balance;
+
+      await pst.writeInteraction(
+        {
+          function: 'transfer',
+          target: 'uhE-QeYS8i4pmUtnxQyHD7dzXFNaJ9oMK-IM-QPNY6M',
+          qty: 100
+        },
+        { strict: true }
+      )
+
+      expect((await pst.currentBalance(walletAddress)).balance).toEqual(startBalance - 100);
+    });
+
+  })
 });

--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -4,7 +4,7 @@ import { InteractionResult } from '../core/modules/impl/HandlerExecutorFactory';
 import { EvaluationOptions, EvalStateResult } from '../core/modules/StateEvaluator';
 import { GQLNodeInterface } from '../legacy/gqlResult';
 import { ArTransfer, Tags, ArWallet } from './deploy/CreateContract';
-import { SignatureType } from './Signature';
+import { CustomSignature } from './Signature';
 import { EvaluationOptionsEvaluator } from './EvaluationOptionsEvaluator';
 
 export type CurrentTx = { interactionTxId: string; contractTxId: string };
@@ -76,7 +76,7 @@ export interface Contract<State = unknown> {
    *
    * @param signer - either {@link ArWallet} that will be connected to this contract or custom {@link SigningFunction}
    */
-  connect(signature: ArWallet | SignatureType): Contract<State>;
+  connect(signature: ArWallet | CustomSignature): Contract<State>;
 
   /**
    * Allows to set ({@link EvaluationOptions})

--- a/src/contract/deploy/CreateContract.ts
+++ b/src/contract/deploy/CreateContract.ts
@@ -1,5 +1,5 @@
 import { JWKInterface } from 'arweave/node/lib/wallet';
-import { SignatureType } from '../../contract/Signature';
+import { CustomSignature } from '../../contract/Signature';
 import { Source } from './Source';
 import { EvaluationOptions } from '../../core/modules/StateEvaluator';
 import { WarpPluginType } from '../../core/WarpPlugin';
@@ -29,7 +29,7 @@ export const BUNDLR_NODES = ['node1', 'node2'] as const;
 export type BundlrNodeType = typeof BUNDLR_NODES[number];
 
 export interface CommonContractData {
-  wallet: ArWallet | SignatureType;
+  wallet: ArWallet | CustomSignature;
   initState: string;
   tags?: Tags;
   transfer?: ArTransfer;

--- a/src/contract/deploy/Source.ts
+++ b/src/contract/deploy/Source.ts
@@ -1,6 +1,6 @@
 import { ArWallet } from './CreateContract';
 import { SourceData } from './impl/SourceImpl';
-import { SignatureType } from '../../contract/Signature';
+import { CustomSignature } from '../../contract/Signature';
 import Transaction from 'arweave/node/lib/transaction';
 export interface Source {
   /**
@@ -8,7 +8,7 @@ export interface Source {
    * @param sourceData - contract source data
    * @param wallet - either Arweave wallet or custom signature type
    */
-  createSourceTx(sourceData: SourceData, wallet: ArWallet | SignatureType): Promise<Transaction>;
+  createSourceTx(sourceData: SourceData, wallet: ArWallet | CustomSignature): Promise<Transaction>;
 
   /**
    * allows to save contract source

--- a/src/contract/deploy/impl/DefaultCreateContract.ts
+++ b/src/contract/deploy/impl/DefaultCreateContract.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
 import Arweave from 'arweave';
 import Transaction from 'arweave/node/lib/transaction';
-import { Signature, SignatureType } from '../../../contract/Signature';
 import { WarpFetchWrapper } from '../../../core/WarpFetchWrapper';
+import { Signature, CustomSignature } from '../../../contract/Signature';
 import { SmartWeaveTags } from '../../../core/SmartWeaveTags';
 import { Warp } from '../../../core/Warp';
 import { WARP_GW_URL } from '../../../core/WarpFactory';
@@ -182,7 +182,7 @@ export class DefaultCreateContract implements CreateContract {
     }
   }
 
-  async createSourceTx(sourceData: SourceData, wallet: ArWallet | SignatureType): Promise<Transaction> {
+  async createSourceTx(sourceData: SourceData, wallet: ArWallet | CustomSignature): Promise<Transaction> {
     return this.source.createSourceTx(sourceData, wallet);
   }
 

--- a/src/contract/deploy/impl/SourceImpl.ts
+++ b/src/contract/deploy/impl/SourceImpl.ts
@@ -9,7 +9,7 @@ import { LoggerFactory } from '../../../logging/LoggerFactory';
 import { Source } from '../Source';
 import { Buffer } from 'redstone-isomorphic';
 import { Warp } from '../../../core/Warp';
-import { Signature, SignatureType } from '../../../contract/Signature';
+import { Signature, CustomSignature } from '../../../contract/Signature';
 import Transaction from 'arweave/node/lib/transaction';
 import { WARP_GW_URL } from '../../../core/WarpFactory';
 import { TagsParser } from '../../../core/modules/impl/TagsParser';
@@ -32,9 +32,9 @@ export class SourceImpl implements Source {
   private readonly logger = LoggerFactory.INST.create('Source');
   private signature: Signature;
 
-  constructor(private readonly warp: Warp) {}
+  constructor(private readonly warp: Warp) { }
 
-  async createSourceTx(sourceData: SourceData, wallet: ArWallet | SignatureType): Promise<Transaction> {
+  async createSourceTx(sourceData: SourceData, wallet: ArWallet | CustomSignature): Promise<Transaction> {
     this.logger.debug('Creating new contract source');
 
     const { src, wasmSrcCodeDir, wasmGlueCode } = sourceData;
@@ -235,7 +235,7 @@ function dummyImports(moduleImports: WebAssembly.ModuleImportDescriptor[]) {
     if (!Object.prototype.hasOwnProperty.call(imports, moduleImport.module)) {
       imports[moduleImport.module] = {};
     }
-    imports[moduleImport.module][moduleImport.name] = function () {};
+    imports[moduleImport.module][moduleImport.name] = function () { };
   });
 
   return imports;

--- a/src/core/Warp.ts
+++ b/src/core/Warp.ts
@@ -22,7 +22,7 @@ import { WarpBuilder } from './WarpBuilder';
 import { WarpPluginType, WarpPlugin, knownWarpPlugins } from './WarpPlugin';
 import { SortKeyCache } from '../cache/SortKeyCache';
 import { ContractDefinition, SrcCache } from './ContractDefinition';
-import { SignatureType } from '../contract/Signature';
+import { CustomSignature } from '../contract/Signature';
 import { SourceData } from '../contract/deploy/impl/SourceImpl';
 import Transaction from 'arweave/node/lib/transaction';
 
@@ -90,7 +90,7 @@ export class Warp {
     return await this.createContract.register(id, bundlrNode);
   }
 
-  async createSourceTx(sourceData: SourceData, wallet: ArWallet | SignatureType): Promise<Transaction> {
+  async createSourceTx(sourceData: SourceData, wallet: ArWallet | CustomSignature): Promise<Transaction> {
     return await this.createContract.createSourceTx(sourceData, wallet);
   }
 


### PR DESCRIPTION
This MR solve problem where in strict mode, `customSignature` is not resolving to proper address.

It fails here: https://github.com/warp-contracts/warp/blob/main/src/contract/HandlerBasedContract.ts#L581 (thanks @asiaziola)
When we try to decode `address` from `signature` and we strictly assume that it is arweave `signature`. It only happens when `{stricit : true}`.

To solve this issue I extract owner assigned by `signature.signer` function and it solves the issues.

However, I also wanted to remove this code https://github.com/warp-contracts/warp/blob/main/src/contract/HandlerBasedContract.ts#L581, because of it - we are signing twice per one interaction (one dummy interaction just to get address and second real one). If interaction is signed by metaMask for example it will break the ux (two pop ups). However, when i removed this logic, it broke internal writes integration tests, so I left it there.

I have also tested it with - https://github.com/warp-contracts/warp-contracts-plugins/blob/main/warp-contracts-plugin-signature/src/server/evm/evmSignature.ts I didnt want to bring plugin as dependency so it is not in tests