### PR TITLE
fix: smartweave global in constructor

### DIFF
--- a/src/__tests__/integration/basic/constructor.test.ts
+++ b/src/__tests__/integration/basic/constructor.test.ts
@@ -121,7 +121,7 @@ describe('Constructor', () => {
       });
     });
 
-    describe('Constructor has access to all smartweave globals', () => {
+    describe('Constructor has access to part of smartweave globals', () => {
       it('should assign as caller deployer of contract', async () => {
         const contract = await deployContract({});
 
@@ -179,6 +179,22 @@ describe('Constructor', () => {
         cachedValue: { state: state2 }
       } = await contract.readState();
       expect(state2.counter).toStrictEqual(2);
+    });
+
+    it('should fail to access block data', async () => {
+      const contract = await deployContract({ addToState: { accessBlock: true } });
+
+      await expect(contract.readState()).rejects.toThrowError(
+        'ConstructorError: SmartWeave.block object is not accessible in constructor'
+      );
+    });
+
+    it('should fail to access vrf data', async () => {
+      const contract = await deployContract({ addToState: { accessVrf: true } });
+
+      await expect(contract.readState()).rejects.toThrowError(
+        'ConstructorError: SmartWeave.vrf object is not accessible in constructor'
+      );
     });
 
     describe('Internal writes', () => {

--- a/src/__tests__/integration/data/constructor/constructor.js
+++ b/src/__tests__/integration/data/constructor/constructor.js
@@ -8,10 +8,19 @@ export async function handle(state, action) {
         state.caller2 = SmartWeave.caller;
         await SmartWeave.kv.put("__init", SmartWeave.transaction.id);
 
+        state.counter = action.input.args.counter + 1;
+
         if (action.input.args.fail) {
             throw new ContractError("Fail on purpose")
         }
-        state.counter = action.input.args.counter + 1;
+
+        if (action.input.args.accessBlock) {
+            SmartWeave.block.timestamp;
+        }
+
+        if (action.input.args.accessVrf) {
+            SmartWeave.vrf.data;
+        }
     }
 
     return { state }

--- a/src/contract/deploy/CreateContract.ts
+++ b/src/contract/deploy/CreateContract.ts
@@ -22,7 +22,7 @@ export const emptyTransfer: ArTransfer = {
 };
 
 export type EvaluationManifest = {
-  evaluationOptions: Partial<EvaluationOptions>;
+  evaluationOptions?: Partial<EvaluationOptions>;
   plugins?: WarpPluginType[];
 };
 

--- a/src/core/modules/impl/handler/WasmHandlerApi.ts
+++ b/src/core/modules/impl/handler/WasmHandlerApi.ts
@@ -129,7 +129,7 @@ export class WasmHandlerApi<State> extends AbstractContractHandler<State> {
     initialState: State,
     executionContext: ExecutionContext<State, unknown>
   ): Promise<State> {
-    if (this.contractDefinition.manifest?.evaluationOptions.useConstructor) {
+    if (this.contractDefinition.manifest?.evaluationOptions?.useConstructor) {
       throw Error('Constructor is not implemented for wasm');
     }
     return initialState;


### PR DESCRIPTION
So I have notice (a little bit too late), that `contractTx` differs from `interactionTx`.
Diffs:
1. missing sequencer tags wich can be used to create SmartWeave.block data (timestamp,height,id)
2. missing `block` data , when fetched from warp-gateway or arweave-gateway
3. also `vrf`object won't be accessible for now, it can be in future if required

- 1. and 2. can be fixed by adding extra tags to deployment tx by sequencer, (when sequencer is not used extra query will be needed)
- 3. Is also fixable, however we don't know if anybody will use it. So we can wait for community requesting this feature.

This MR:
- I disabled vrf and block access by using proxy to provide understable error, I will add info in academy (edit added)

