### PR TITLE
fix(ArweaveGatewayInteractionsLoader): avoid processing duplicate int…

### DIFF
--- a/src/core/modules/impl/ArweaveGatewayInteractionsLoader.ts
+++ b/src/core/modules/impl/ArweaveGatewayInteractionsLoader.ts
@@ -94,25 +94,13 @@ export class ArweaveGatewayInteractionsLoader implements InteractionsLoader {
      */
     interactions = interactions.filter((i) => i.node.block && i.node.block.id && i.node.block.height);
     // deduplicate any interactions that may have been provided twice 
-    const deduplicatedInteractions = [];
-    // used to store block specific interactions 
-    let tempInteractions = [];
-    let currentBlockHeight;
-    for(const i of interactions){
-        // flush interactions to deduplicated
-        if(currentBlockHeight != i.node.block.height){
-            deduplicatedInteractions.push(...tempInteractions);
-            tempInteractions = [];
-            currentBlockHeight = i.node.block.height;
-        }
-        const interactonTxId = i.node.id;
-        const existingInteraction = temp.find((int) => int.node.id === interactonTxId);
-        if(!existingInteraction){
-            temp.push(i);
+    const interactionMap = new Map();
+    for (const interaction of interactions) {
+        if (!interactionMap.has(interaction.node.id)) {
+            interactionMap.set(interaction.node.id, interaction);
         }
     }
-    // flush remaining interactions to deduplicatedInteractions array
-    deduplicatedInteractions.push(...tempInteractions);
+    const deduplicatedInteractions = Array.from(interactionMap.values());
 
     // note: this operation adds the "sortKey" to the interactions
     let sortedInteractions = await this.sorter.sort(deduplicatedInteractions);

--- a/src/core/modules/impl/ArweaveGatewayInteractionsLoader.ts
+++ b/src/core/modules/impl/ArweaveGatewayInteractionsLoader.ts
@@ -93,9 +93,18 @@ export class ArweaveGatewayInteractionsLoader implements InteractionsLoader {
      * - we're removing all the interactions, that have null block data.
      */
     interactions = interactions.filter((i) => i.node.block && i.node.block.id && i.node.block.height);
+    // dedeuplicate any interactions that may have been provided twice 
+    const dedeuplicatedInteractions = []
+    for(const i of dedeuplicatedInteractions){
+        const interactonTxId = i.node.id;
+        const existingInteraction = dedeuplicatedInteractions.find((int) => int.node.id === interactonTxId);
+        if(!existingInteraction){
+            dedeuplicatedInteractions.push(i);
+        }
+    }
 
     // note: this operation adds the "sortKey" to the interactions
-    let sortedInteractions = await this.sorter.sort(interactions);
+    let sortedInteractions = await this.sorter.sort(dedeuplicatedInteractions);
 
     if (fromSortKey && toSortKey) {
       sortedInteractions = sortedInteractions.filter((i) => {


### PR DESCRIPTION
…eractions

This change ensures that interactions provided to `ArweaveGatewayInteractionsLoader` are deduplicated before processing. By doing it before `sortKey`'s you prevent duplicate computation of an async request.

This can be done several different ways - and some more optimal then others.

Another option using only arrays in [fb80c82](https://github.com/warp-contracts/warp/pull/484/commits/fb80c8204bef9ca584cf70757507ec9b9759da08)

```typescript
// deduplicate any interactions that may have been provided twice 
const deduplicatedInteractions = [];
// used to store block specific interactions 
let tempInteractions = [];
let currentBlockHeight;
for(const i of interactions){
    // flush interactions to deduplicated
    if(currentBlockHeight != i.node.block.height){
        deduplicatedInteractions.push(...tempInteractions);
        tempInteractions = [];
        currentBlockHeight = i.node.block.height;
    }
    const interactonTxId = i.node.id;
    const existingInteraction = tempInteractions.find((int) => int.node.id === interactonTxId);
    if(!existingInteraction){
        tempInteractions.push(i);
    }
}
// flush remaining interactions to deduplicatedInteractions array
deduplicatedInteractions.push(...tempInteractions);
```