### PR TITLE
 fix(#497): default validity to empty object, set interaction validity before using it when updating interaction call

### DIFF
--- a/src/core/modules/impl/CacheableStateEvaluator.ts
+++ b/src/core/modules/impl/CacheableStateEvaluator.ts
@@ -182,7 +182,7 @@ export class CacheableStateEvaluator extends DefaultStateEvaluator {
     if (transaction.confirmationStatus !== undefined && transaction.confirmationStatus !== 'confirmed') {
       return;
     }
-    const stateToCache = new EvalStateResult(state.state, state.validity, state.errorMessages || {});
+    const stateToCache = new EvalStateResult(state.state, state.validity || {}, state.errorMessages || {});
 
     this.cLogger.debug('Putting into cache', {
       contractTxId,

--- a/src/core/modules/impl/CacheableStateEvaluator.ts
+++ b/src/core/modules/impl/CacheableStateEvaluator.ts
@@ -52,8 +52,8 @@ export class CacheableStateEvaluator extends DefaultStateEvaluator {
 
     const isFirstEvaluation = cachedState == null;
     let baseState = isFirstEvaluation ? executionContext.contractDefinition.initState : cachedState.cachedValue.state;
-    const baseValidity = isFirstEvaluation ? {} : cachedState.cachedValue.validity;
-    const baseErrorMessages = isFirstEvaluation ? {} : cachedState.cachedValue.errorMessages;
+    const baseValidity = isFirstEvaluation ? {} : cachedState.cachedValue.validity || {};
+    const baseErrorMessages = isFirstEvaluation ? {} : cachedState.cachedValue.errorMessages || {};
 
     if (isFirstEvaluation) {
       baseState = await executionContext.handler.maybeCallStateConstructor(
@@ -81,7 +81,7 @@ export class CacheableStateEvaluator extends DefaultStateEvaluator {
     // eval state for the missing transactions - starting from the latest value from cache.
     return await this.doReadState(
       missingInteractions,
-      new EvalStateResult(baseState, baseValidity, baseErrorMessages || {}),
+      new EvalStateResult(baseState, baseValidity, baseErrorMessages),
       executionContext
     );
   }

--- a/src/core/modules/impl/DefaultStateEvaluator.ts
+++ b/src/core/modules/impl/DefaultStateEvaluator.ts
@@ -252,6 +252,8 @@ export abstract class DefaultStateEvaluator implements StateEvaluator {
         if (result.type !== 'ok') {
           errorMessages[missingInteraction.id] = errorMessage;
         }
+        const isValidInteraction = result.type === 'ok';
+        validity[missingInteraction.id] = isValidInteraction;
 
         this.logResult<State>(result, missingInteraction, executionContext);
 
@@ -270,8 +272,6 @@ export abstract class DefaultStateEvaluator implements StateEvaluator {
           throw new Error(`Exception while processing ${JSON.stringify(interaction)}:\n${result.errorMessage}`);
         }
 
-        const isValidInteraction = result.type === 'ok';
-        validity[missingInteraction.id] = isValidInteraction;
         currentState = result.state;
 
         const toCache = new EvalStateResult(currentState, validity, errorMessages);


### PR DESCRIPTION
The log below shows that `validity` can be `undefined` when returning from cache, resulting in the errors described in #497. Additionally, moves setting interaction validity before acccessing it below in `interactionCall.update()`.

```
2024-01-26T17:56:55.903Z DEBUG [HandlerBasedContract] Cached state [
  SortKeyCacheResult {
    sortKey: '000001351346,0000000000000,b407f22dec983a4bcaf4a867605ed09aef711cb038eaa49161c7d9a4e17e1661',
    cachedValue: { state: [Object], validity: undefined, errorMessages: {} }
  },
  undefined
]
```