### PR TITLE
fix(exports): fix browser and web exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,12 @@
   "description": "An implementation of the SmartWeave smart contract protocol.",
   "types": "./lib/types/index.d.ts",
   "main": "./lib/cjs/index.js",
-  "browser": {
-    "./lib/cjs/index.js": "./bundles/web.bundle.min.js",
-    "types": "./lib/types/index.d.ts"
-  },
+  "browser": "./bundles/web.bundle.min.js",
   "exports": {
     "./web": {
-      "import": "./bundles/web.bundle.min.js",
+      "import": "./lib/mjs/index.js",
+      "require": "./lib/cjs/index.js",
+      "browser": "./bundles/web.bundle.min.js",
       "types": "./lib/types/index.d.ts"
     },
     "./mjs": {


### PR DESCRIPTION
By default - any project using `/web` should get `mjs` build - not the bundled version with no default export. Also cleans up redundant types.

Fixes the error in #505

You can optionally remove the `browser` field in `/mjs` given only projects using `nodenext` can access named exports - but i'll leave that to you. 