### PR TITLE
Feat optional input format

### DIFF
--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -40,6 +40,7 @@ export interface DREContractStatusResponse<State> {
 export type WarpOptions = {
   vrf?: boolean;
   disableBundling?: boolean;
+  inputFormatAsData?: boolean;
   manifestData?: { [path: string]: string };
 };
 
@@ -217,8 +218,7 @@ export interface Contract<State = unknown> {
    */
   writeInteraction<Input = unknown>(
     input: Input,
-    options?: WriteInteractionOptions,
-    inputFormatAsData?: boolean
+    options?: WriteInteractionOptions
   ): Promise<WriteInteractionResponse | null>;
 
   /**

--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -217,7 +217,8 @@ export interface Contract<State = unknown> {
    */
   writeInteraction<Input = unknown>(
     input: Input,
-    options?: WriteInteractionOptions
+    options?: WriteInteractionOptions,
+    inputFormatAsData?: boolean
   ): Promise<WriteInteractionResponse | null>;
 
   /**

--- a/src/contract/HandlerBasedContract.ts
+++ b/src/contract/HandlerBasedContract.ts
@@ -427,6 +427,7 @@ export class HandlerBasedContract<State> implements Contract<State> {
 
     if (!this.maxInteractionDataItemSizeBytes) {
       const response = fetch(`${stripTrailingSlash(this.warp.gwUrl())}`);
+      this.logger.info('confirm response', response);
       this.maxInteractionDataItemSizeBytes = (
         await getJsonResponse<{ maxInteractionDataItemSizeBytes: number }>(response)
       ).maxInteractionDataItemSizeBytes;

--- a/src/contract/HandlerBasedContract.ts
+++ b/src/contract/HandlerBasedContract.ts
@@ -334,8 +334,7 @@ export class HandlerBasedContract<State> implements Contract<State> {
 
   async writeInteraction<Input>(
     input: Input,
-    options?: WriteInteractionOptions,
-    inputFormatAsData?: boolean
+    options?: WriteInteractionOptions
   ): Promise<WriteInteractionResponse | null> {
     this.logger.info('Write interaction', { input, options });
     if (!this._signature) {
@@ -354,6 +353,7 @@ export class HandlerBasedContract<State> implements Contract<State> {
     const effectiveDisableBundling = options?.disableBundling === true;
     const effectiveReward = options?.reward;
     const effectiveManifestData = options?.manifestData;
+    const effectiveInputFormatOption = options?.inputFormatAsData;
 
     const bundleInteraction = interactionsLoader.type() == 'warp' && !effectiveDisableBundling;
 
@@ -382,7 +382,7 @@ export class HandlerBasedContract<State> implements Contract<State> {
         strict: effectiveStrict,
         vrf: effectiveVrf,
         manifestData: effectiveManifestData,
-        inputFormatAsData: inputFormatAsData
+        inputFormatAsData: effectiveInputFormatOption
       });
     } else {
       const interactionTx = await this.createInteraction(


### PR DESCRIPTION
This pull-request resolves #516 
It addes a boolean option `inputFormatAsData` to overide the behaviour where a warp interaction `Input-Format` defaults to `tag`, hence allowing the SDK user to set `Input-Fomat` to `data` instead. 

This is especially useful if the warp interaction data is expected to be consumed by other applications that have no concept of an Arweave tag but could simply make a http GET request to any Arweave gateway to fetch the desire data by its iteraction id.

All else works the same.