### PR TITLE
fix(exports): add back require and browser exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,14 @@
     },
     "./mjs": {
       "import": "./lib/mjs/index.js",
+      "require": "./lib/cjs/index.js",
+      "browser": "./bundles/web.bundle.min.js",
       "types": "./lib/types/index.d.ts"
     },
     ".": {
       "import": "./lib/mjs/index.js",
+      "require": "./lib/cjs/index.js",
+      "browser": "./bundles/web.bundle.min.js",
       "types": "./lib/types/index.d.ts"
     }
   },


### PR DESCRIPTION
These were unintentionally removed in https://github.com/warp-contracts/warp/commit/b56cede00bdb7c5c004c0d5370aa1df69cf3f7b3

